### PR TITLE
Make compatible with Tensorflow version 1.0 and beyond

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://github.com/philipperemy/tensorflow-phased-lstm/blob/master/official_tens
 
 <hr/>
 
-**NOTE: You can still use this alternative implementation. The code is very similar and it's as fast as the official one (0.8 seconds for a forward-backward pass on a Titan X Maxwell GPU).**
+**NOTE: You can still use this alternative implementation (tested on Tensorflow v1.10). The code is very similar and it's as fast as the official one (0.8 seconds for a forward-backward pass on a Titan X Maxwell GPU).**
 
 ## How to use it?
 ```

--- a/official_tensorflow_phased_lstm.py
+++ b/official_tensorflow_phased_lstm.py
@@ -77,8 +77,8 @@ def main():
 
 def get_parameters():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-m', '--model')  # BasicLSTMCell, PhasedLSTMCell or None
-    parser.add_argument('-g', '--log_file')  # BasicLSTMCell, PhasedLSTMCell or None
+    parser.add_argument('-m', '--model', required=True, help='BasicLSTMCell, PhasedLSTMCell or None')
+    parser.add_argument('-g', '--log_file', default='log.tsv')
     args = parser.parse_args()
     model_str = args.model
     log_file = args.log_file

--- a/phased_lstm.py
+++ b/phased_lstm.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 from tensorflow.contrib.rnn import RNNCell
-from tensorflow.python.ops import rnn_cell_impl
+from tensorflow.contrib.rnn.python.ops import core_rnn_cell
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
@@ -10,8 +10,7 @@ from tensorflow.python.ops import variable_scope as vs
 from tensorflow.python.ops.math_ops import sigmoid
 from tensorflow.python.ops.math_ops import tanh
 
-_linear = rnn_cell_impl._linear
-
+_linear = core_rnn_cell._linear
 
 def random_exp_initializer(minval=0, maxval=None, seed=None,
                            dtype=dtypes.float32):
@@ -33,17 +32,6 @@ def random_exp_initializer(minval=0, maxval=None, seed=None,
         return tf.exp(random_ops.random_uniform(shape, minval, maxval, dtype, seed=seed))
 
     return _initializer
-
-
-# Register the gradient for the mod operation. tf.mod() does not have a gradient implemented.
-@ops.RegisterGradient('FloorMod')
-def _mod_grad(op, grad):
-    x, y = op.inputs
-    gz = grad
-    x_grad = gz
-    y_grad = tf.reduce_mean(-(x // y) * gz, axis=[0], keep_dims=True)[0]
-    return x_grad, y_grad
-
 
 def phi(times, s, tau):
     # return tf.div(tf.mod(tf.mod(times - s, tau) + tau, tau), tau)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 tabulate
-tensorflow
+tensorflow>=1.0

--- a/test_cosine.py
+++ b/test_cosine.py
@@ -115,6 +115,8 @@ def gen_async_sin(async_sampling, resolution=None, batch_size=32, on_target_T=(5
         samples = lens
 
     start_times = np.array([np.random.uniform(0, max_len - duration) for duration in lens])
+    max_len = int(max_len)
+
     x = np.zeros((batch_size, max_len, 1))
     y = np.zeros((batch_size, 2))
     t = np.zeros((batch_size, max_len, 1))
@@ -234,7 +236,12 @@ def main(_):
         for step in range(FLAGS.n_epochs):
             train_cost = 0
             train_acc = 0
+
+            print('Working on epoch {}/{}'.format(step+1, FLAGS.n_epochs))
+
             for i in range(FLAGS.b_per_epoch):
+
+                print('  Batch {}/{}'.format(i+1, FLAGS.b_per_epoch))
                 batch_xs, batch_ys, leng, posT, negT = gen_async_sin(FLAGS.async,
                                                                      FLAGS.resolution,
                                                                      FLAGS.batch_size, [FLAGS.min_f_on, FLAGS.max_f_on],


### PR DESCRIPTION
I know this repository is approximately two years old but I needed to run this code for my own research. Had to make some minor changes for TensorFlow v1.0+ compatibility. Although an "official" PhasedLSTMCell now lives in tf.contrib, maybe some people are still interested in running this somewhat easier to read code. Therefore this pull request to make the code compatible with the latest version of TensorFlow again (tested on version 1.10, the current release).